### PR TITLE
Solved bug with multiple arrays sent via a socket:

### DIFF
--- a/examples/Simple/simple_client.py
+++ b/examples/Simple/simple_client.py
@@ -2,15 +2,22 @@
 
 import logging
 import numpy as np
-from numpysocket import NumpySocket
+from numpysocket.numpysocket import NumpySocket
 
 
 logger = logging.getLogger("simple client")
 logger.setLevel(logging.INFO)
 
 with NumpySocket() as s:
-    s.connect(("localhost", 9999))
+    s.connect(("localhost", 9998))
 
     logger.info("sending numpy array:")
     frame = np.arange(1000)
     s.sendall(frame)
+
+    frame = np.array([6, 7, 8, 9, 1, 2, 3])
+    s.sendall(frame)
+
+    arr = s.recv()
+    logger.info("array:")
+    logger.info(arr)

--- a/examples/Simple/simple_server.py
+++ b/examples/Simple/simple_server.py
@@ -1,21 +1,27 @@
 #!/usr/bin/python3
 
 import logging
-
-from numpysocket import NumpySocket
+import numpy as np
+from numpysocket.numpysocket import NumpySocket
 
 logger = logging.getLogger("simple server")
 logger.setLevel(logging.INFO)
 
 with NumpySocket() as s:
-    s.bind(("", 9999))
+    s.bind(("", 9998))
     s.listen()
     conn, addr = s.accept()
     with conn:
         logger.info(f"connected: {addr}")
-        frame = conn.recv()
 
+        frame = conn.recv()
         logger.info("array received")
         logger.info(frame)
+
+        frame = conn.recv()
+        logger.info("array received")
+        logger.info(frame)
+
+        conn.sendall(np.array([1, 2, 3]))
 
     logger.info(f"disconnected: {addr}")

--- a/numpysocket/numpysocket.py
+++ b/numpysocket/numpysocket.py
@@ -3,45 +3,55 @@
 from io import BytesIO
 import logging
 import socket
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 
 
 class NumpySocket(socket.socket):
+
+    prev = None
+
     def sendall(self, frame: np.ndarray) -> None:  # type: ignore[override]
         out = self.__pack_frame(frame)
+
         super().sendall(out)
         logging.debug("frame sent")
+
 
     def recv(self, bufsize: int = 1024) -> np.ndarray:  # type: ignore[override]
         length = None
         frame_buffer = bytearray()
+        frames = []
         while True:
-            data = super().recv(bufsize)
+
+            if self.prev == None or len(self.prev) == 0:
+                data = super().recv(bufsize)
+            else:
+                data = self.prev
+                self.prev = None
+
             if len(data) == 0:
                 return np.array([])
             frame_buffer += data
-            if len(frame_buffer) == length:
-                break
-            while True:
-                if length is None:
-                    if b":" not in frame_buffer:
-                        break
-                    length_str, _, frame_buffer = frame_buffer.partition(b":")
-                    length = int(length_str)
-                if len(frame_buffer) < length:
-                    break
 
-                frame_buffer = frame_buffer[length:]
-                length = None
+            if length is None:
+                if b":" not in frame_buffer:
+                    assert(False) # throw error not np array
+                length_str, ignored, frame_buffer = frame_buffer.partition(b":")
+                length = int(length_str)
+
+            if len(frame_buffer) >= length:
+                frame = np.load(BytesIO(frame_buffer[:length]), allow_pickle=True)["frame"]
+                self.prev = frame_buffer[length:]
+                frames.append(frame)
                 break
 
         frame = np.load(BytesIO(frame_buffer), allow_pickle=True)["frame"]
         logging.debug("frame received")
         return frame
 
-    def accept(self) -> tuple["NumpySocket", Union[tuple[str, int], tuple[Any, ...]]]:
+    def accept(self):
         fd, addr = super()._accept()  # type: ignore
         sock = NumpySocket(super().family, super().type, super().proto, fileno=fd)
 


### PR DESCRIPTION
- updated the numpysocket to use a prev value which is persistent across multiple sends and remembers if the last frame contained the begining a new numpy array.  #20 
- removed the "double" while True since I find no use in it, but possibly induced some bugs. It also seems that this change resulted in an improvement in transfer times.

